### PR TITLE
Restore user save slot after Instant Play resume

### DIFF
--- a/main.c
+++ b/main.c
@@ -656,8 +656,10 @@ int state_resume(void) {
 	int ret = 0;
 
 	if (resume_slot != -1) {
+		int prev_state_slot = state_slot;
 		state_slot = resume_slot;
 		ret = state_read();
+		state_slot = prev_state_slot;
 		resume_slot = -1;
 	}
 	return ret;


### PR DESCRIPTION
## Problem

`state_resume()` assigns `resume_slot` to the global `state_slot` and never restores it:

```c
int state_resume(void) {
	int ret = 0;

	if (resume_slot != -1) {
		state_slot = resume_slot;
		ret = state_read();
		resume_slot = -1;
	}
	return ret;
}
```

`FK_Resume()` sets `resume_slot = AUTOSAVE_SLOT` (99) whenever the autosave is taken, so afterwards **`state_slot` stays at 99 for the rest of the session**. Since resuming is the normal way to get back into a game, this is the steady state for anyone who plays by closing and reopening the device.

**The user's quicksaves are written to the autosave slot and then deleted.**

The Save State / Load State hotkeys resolve their filename from `state_slot` via `state_file_name()`, so after a resume they read and write `.st99` instead of the user's slot. `FK_Resume()` calls `remove(autosave_path)` after resuming, so every quicksave made during that session is discarded at the next resume. Meanwhile `.st0` is never written and keeps whatever it held previously, which for a player who always resumes may be very old.

Nothing in the UI indicates the slot moved, and within a session the two hotkeys stay consistent with each other because both address `.st99` — so the loss is silent.

Secondary effect: `MAX_SAVE_SLOTS` is 9 (`funkey/fk_menu.c:89`) and `FK_RunMenu()` clamps with `state_slot = (state_slot % MAX_SAVE_SLOTS)` on entry (`funkey/fk_menu.c:978`). Since **`99 % 9 == 0`**, opening the menu during such a session moves the slot from the autosave file to slot 0, so a following Load State restores an unrelated old state instead of the quicksave just made.

## Reproduction

Verified on an Anbernic RG Nano running FunKey-OS (`fps-classics`), gambatte core, with the stock build. Requires an autosave (`.st99`) to be present for the game.

**Path 1 — resume from power-on**

1. While in a game, long-press to power off. `FK_Suspend()` writes `.st99` and `picoarch-auto.cfg`.
2. Power on. The device resumes into the game. `load_config()` sets `instant_play = true` because the auto config exists, so `FK_Resume()` takes the autosave and `state_slot` becomes 99.
3. Move to a clearly different point **B**.
4. Press Save State. This writes **`.st99`**, not `.st0`.
5. Press Load State. You return to **B** and it looks correct — both hotkeys are addressing `.st99`.
6. Open the menu and close it again, without saving or loading. The clamp maps 99 to 0.
7. Press Load State. **An unrelated old state from slot 0 loads.**

**Path 2 — launching fresh, answering Yes to the resume prompt**

1. Exit to the launcher. `finish()` calls `FK_Autosave()`, so `.st99` is written, but no auto config is left behind.
2. Launch the game from the launcher. With no auto config, `instant_play` is false, so `FK_Resume()` calls `FK_RunResumeMenu()` and asks whether to resume.
3. Answer **Yes**. `resume_slot = AUTOSAVE_SLOT`, `state_slot` becomes 99, and steps 3-7 above follow identically.

Answering **No** leaves `state_slot` at 0 and the problem does not occur, which is part of why this is easy to miss.

Inspecting the save directory after step 4 shows `.st0` unchanged despite Save State having been pressed, while `.st99` is freshly written.

## Fix

Save and restore `state_slot` around the read, mirroring the pattern `FK_Autosave()` already uses for the same global:

```c
int prev_state_slot = state_slot;
state_slot = resume_slot;
ret = state_read();
state_slot = prev_state_slot;
```

No caller depends on `state_slot` retaining `resume_slot` after the call — `FK_Resume()` uses the autosave path it computed earlier, and the callers in `menu.c` and `main.c` do not read the slot afterwards. With the slot restored, `state_slot` never holds 99 outside this function, so the `% MAX_SAVE_SLOTS` clamp becomes a no-op rather than a trap, and the hotkeys keep addressing the slot the player is actually using.

## Scope

This only stops the resume from clobbering the user's slot. It does not change the fact that `state_slot` is not persisted in the config, so a slot chosen from the menu is still forgotten when the game is next launched and the default of 0 applies. That is separate and not addressed here.

## Verification

- Cross-compiled for `platform=funkey-s` against FunKey-sdk-2.3.0 (`arm-funkey-linux-musleabihf-gcc` 10.2.0); builds clean.
- Both reproduction paths above were confirmed on hardware against the stock build.
- The patched binary was then run on the same device, packaged as an OPK calling the stock `gambatte_libretro.so`. **Neither path reproduces any more: after a resume, Save State writes the user's slot and Load State returns to it, both when resuming from power-on and when launching fresh and answering Yes to the resume prompt.**
